### PR TITLE
[codex] Update wabot framework to 0.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wabot-dev/framework": "^0.5.10"
+        "@wabot-dev/framework": "0.5.11"
       },
       "devDependencies": {
-        "@swc/core": "^1.15.21",
-        "@types/ws": "^8.18.1",
-        "prettier": "^3.8.1",
-        "tsup": "^8.5.1"
+        "@swc/core": "1.15.21",
+        "@types/ws": "8.18.1",
+        "prettier": "3.8.1",
+        "tsup": "8.5.1"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -772,7 +772,7 @@
       ],
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.0",
@@ -783,6 +783,7 @@
       ],
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -804,6 +805,7 @@
       ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -818,6 +820,7 @@
       ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -830,7 +833,8 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.0",
@@ -869,6 +873,7 @@
       ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1387,9 +1392,9 @@
       }
     },
     "node_modules/@wabot-dev/framework": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@wabot-dev/framework/-/framework-0.5.10.tgz",
-      "integrity": "sha512-0c28Ysc2ViOmOSKhyduEEeL49J8klexFJZOhGnOwEazYefoJexCr/wttQZ2FaN3yWfJY2UjoF1PF96KCYMfHiw==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@wabot-dev/framework/-/framework-0.5.11.tgz",
+      "integrity": "sha512-vTA69RVqhguAKcQTLzs3E1+z8rn0MIKmFY67tP3fmDJRe4dT9hWpvoN6puW64hQGBPE6LoGpLNhQrHY35e+0Ow==",
       "license": "MIT",
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.60.0",
@@ -1526,13 +1531,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1628,16 +1626,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2588,6 +2576,45 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -3100,22 +3127,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {

--- a/package.json
+++ b/package.json
@@ -16,19 +16,19 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@wabot-dev/framework": "^0.5.10"
+    "@wabot-dev/framework": "0.5.11"
   },
   "devDependencies": {
-    "@swc/core": "^1.15.21",
-    "@types/ws": "^8.18.1",
-    "prettier": "^3.8.1",
-    "tsup": "^8.5.1"
+    "@swc/core": "1.15.21",
+    "@types/ws": "8.18.1",
+    "prettier": "3.8.1",
+    "tsup": "8.5.1"
   },
   "overrides": {
-    "minimatch": "^9.0.7",
-    "picomatch": "^4.0.4",
-    "qs": "^6.15.0",
-    "rollup": "^4.60.0",
-    "socket.io-parser": "^4.2.6"
+    "minimatch": "9.0.7",
+    "picomatch": "4.0.4",
+    "qs": "6.15.0",
+    "rollup": "4.60.0",
+    "socket.io-parser": "4.2.6"
   }
 }


### PR DESCRIPTION
## Summary
This branch updates the template to use `@wabot-dev/framework` version `0.5.11` and aligns the dependency declarations to exact versions in both `dependencies` and `devDependencies`.

## Problem
The template was still pinned to framework version `0.5.10`, which meant new projects created from this repository would continue installing an older framework release instead of the latest intended version.

## User impact
Without this update, consumers of the template could start from an outdated framework version and miss fixes or behavior shipped in `0.5.11`. In addition, the broader use of range specifiers in the manifest made installs less predictable across environments.

## Root cause
The repository metadata and lockfile had not been refreshed after the framework release, so the package manifest and the resolved dependency graph still reflected the previous version and semver ranges.

## Fix
The branch bumps `@wabot-dev/framework` from `0.5.10` to `0.5.11`, updates the lockfile accordingly, and normalizes dependency and override entries to exact versions so installs are more reproducible.

## Validation
I ran `npm run tsc` successfully.
I ran `npm run test:unit` successfully; the command completed cleanly and reported no unit test files in the repository.
